### PR TITLE
fix: prevent .env leaking; add .env.example + docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY="your-api-key"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ git clone https://github.com/whoiskatrin/chart-gpt.git
 cd chart-gpt
 ```
 
+Then duplicate the `.env.example` template with `cp .env.example .env` and add your OpenAI API key:
+
+```
+OPENAI_API_KEY="your-api-key"
+```
+
 Then install the dependencies and start the development server:
 
 ```


### PR DESCRIPTION
# Problem Description

- `.env` should never be directly committed as it increases the risk of leaking **secrets** (credentials) (the OpenAI API key in this key). (for the reasoning see https://dev.to/somedood/please-dont-commit-env-3o9h)
- Currently, the `.env` file is part of the public repository. This encourages bad security practices. The `.env` file should be removed and replaced with a `.env.example` template

# Proposed Solution

- [x] A better practice is to provide a `.env.example` template which the user then copies with `cp .env.example .env`
- [ ] TODO: `.env` is included in `.gitignore`, yet the file is in the repository. The file should be removed from tracking by untracking it with `git rm --cached .env` (see https://stackoverflow.com/a/1274447) . 

# Changes in this pull request

1. added `.env.example`
2. provided instructions for adding the API key to `README.md`
