### PR TITLE
Let user specify color of chart

### DIFF
--- a/components/ChartComponent.tsx
+++ b/components/ChartComponent.tsx
@@ -108,7 +108,7 @@ function mixColors(colors: string[], randomFactor = 0.1): string {
 
 //TODO: dynamic keys instead of default value
 export const Chart: React.FC<ChartProps> = ({ data, chartType }) => {
-  const color = mixColors(colors);
+  const color = data.length > 0 ? data[0]["color"] : mixColors(colors);
   const value = data.length > 0 ? Object.keys(data[0])[1] : "value";
   const renderChart = () => {
     chartType = chartType.toLowerCase();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,8 +51,8 @@ const HomePage = () => {
       setChartType(chartTypeResponse.data);
 
       const libraryPrompt = `Generate a valid JSON in which each element is an object. Strictly using this FORMAT and naming:
-[{ "name": "a", "value": 12, "color": "#4285F4" }] for Recharts API. Make sure field name always stays named name. Instead of naming value field value in JSON, name it based on user metric.\n Make sure the format use double quotes and property names are string literals. \n\n${inputValue}\n`;
-
+[{ "name": "a", "value": 12, "color": "#4285F4" }] for Recharts API. Make sure field name always stays named name. Instead of naming value field value in JSON, name it based on user metric. If the user includes a color or a hex code for a color, replace #4285F4 with this user inputted color value. \n Make sure the format uses double quotes and property names are string literals. \n\n${inputValue}\n`;
+      console.log(libraryPrompt);
       const chartDataResponse = await axios.post("/api/parse-graph", {
         prompt: libraryPrompt,
       });
@@ -61,6 +61,7 @@ const HomePage = () => {
 
       try {
         parsedData = JSON.parse(chartDataResponse.data);
+        console.log(parsedData);
       } catch (error) {
         setError(true);
         console.error("Failed to parse chart data:", error);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -52,7 +52,7 @@ const HomePage = () => {
 
       const libraryPrompt = `Generate a valid JSON in which each element is an object. Strictly using this FORMAT and naming:
 [{ "name": "a", "value": 12, "color": "#4285F4" }] for Recharts API. Make sure field name always stays named name. Instead of naming value field value in JSON, name it based on user metric. If the user includes a color or a hex code for a color, replace #4285F4 with this user inputted color value. \n Make sure the format uses double quotes and property names are string literals. \n\n${inputValue}\n`;
-      console.log(libraryPrompt);
+      
       const chartDataResponse = await axios.post("/api/parse-graph", {
         prompt: libraryPrompt,
       });
@@ -61,7 +61,6 @@ const HomePage = () => {
 
       try {
         parsedData = JSON.parse(chartDataResponse.data);
-        console.log(parsedData);
       } catch (error) {
         setError(true);
         console.error("Failed to parse chart data:", error);


### PR DESCRIPTION
Two small changes, one to instruct chatGPT to replace example color hex in output with user supplied color if present. The second to rely on this value for coloring chart elements with the fallback of random color from `mixColors()`.