### PR TITLE
refactor: Updated Tremor and fix overflow behaviour

### DIFF
--- a/components/atoms/SegmentedControl.tsx
+++ b/components/atoms/SegmentedControl.tsx
@@ -59,7 +59,7 @@ export const SegmentedControlList = ({
   return (
     <Tab.List
       className={clsx(
-        'bg-zinc-100 dark:bg-zinc-800 flex h-10 appearance-none items-center overflow-scroll rounded-lg p-1',
+        'bg-zinc-100 dark:bg-zinc-800 flex h-10 appearance-none items-center overflow-auto rounded-lg p-1',
         {
           'max-w-fit': !fullWidth,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nextjs",
+  "name": "chartgpt",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextjs",
+      "name": "chartgpt",
       "version": "0.1.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.3.0",
@@ -23,7 +23,7 @@
         "@supabase/auth-helpers-react": "^0.3.1",
         "@supabase/supabase-js": "^2.21.0",
         "@tailwindcss/forms": "^0.5.3",
-        "@tremor/react": "^2.4.0",
+        "@tremor/react": "^2.7.0",
         "@uiball/loaders": "^1.2.6",
         "@vercel/analytics": "^0.1.11",
         "ajv": "^8.12.0",
@@ -1703,9 +1703,9 @@
       }
     },
     "node_modules/@tremor/react": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@tremor/react/-/react-2.4.0.tgz",
-      "integrity": "sha512-UszaUHKdkNDbb9DX8Eqrcy04kDGwRHO3osy5JQChbVNFYcoeBG/1scD4vCPrRak86MdNk2vleA6V48qkJZDzvQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tremor/react/-/react-2.7.0.tgz",
+      "integrity": "sha512-dyjdWLzyYdDyKqw7VxXM79rVo9TqP2NXtFqq+1PPkrFIEtGQzZKBICAeQ7BHltvNBx79fpc+N/rUK5HM6bR5IA==",
       "dependencies": {
         "@floating-ui/react": "^0.19.1",
         "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@supabase/auth-helpers-react": "^0.3.1",
     "@supabase/supabase-js": "^2.21.0",
     "@tailwindcss/forms": "^0.5.3",
-    "@tremor/react": "^2.4.0",
+    "@tremor/react": "^2.7.0",
     "@uiball/loaders": "^1.2.6",
     "@vercel/analytics": "^0.1.11",
     "ajv": "^8.12.0",


### PR DESCRIPTION
Heya! This PR:

* Updates Tremor to the newest version (2.4 → 2.7)
* Solves an overflow issue I had in my browsers (Vivaldi 6.0.2979.18 + Safari 16.4) in the `SegmentedControl` component. See screenshot below
<img width="490" alt="CleanShot 2023-05-19 at 01 00 24@2x" src="https://github.com/whoiskatrin/chart-gpt/assets/41927988/c8c845fa-39d0-4fd8-b79e-1f0d3ac3877f">
